### PR TITLE
feat: add 'system' refresh event after goes online

### DIFF
--- a/src/store/socket-message/socket.ts
+++ b/src/store/socket-message/socket.ts
@@ -162,6 +162,7 @@ export class SocketStore extends EventTarget {
       'page',
       'indexedDB',
       'mpStorage',
+      'system',
     ];
     refreshData.forEach((i) => {
       this.unicastMessage({


### PR DESCRIPTION
以往，SDK 的 `SystemPlugin` 初始化完成后发的消息会在 `socketStore.messages` 缓存。在 SDK 新增 `messageCapacity` 配置字段后，`SystemPlugin` 初始化后不再直接发消息。要让调试端上线后向 SDK 发一条 `system` 类型的 `refresh` 事件。

相关内容：
- https://github.com/HuolalaTech/page-spy/pull/76
- https://github.com/HuolalaTech/page-spy-web/issues/169