### PR TITLE
新消息类型： client-info 

### DIFF
--- a/src/pages/Devtools/BrowserFrame/index.tsx
+++ b/src/pages/Devtools/BrowserFrame/index.tsx
@@ -10,7 +10,6 @@ import { Button, Space, Spin } from 'antd';
 import { ElementPanel } from '../ElementPanel';
 import { useTranslation } from 'react-i18next';
 import { useSocketMessageStore } from '@/store/socket-message';
-import { useClientInfoFromMsg } from '@/utils/brand';
 
 function getTime() {
   const date = new Date();
@@ -34,8 +33,9 @@ export const PCFrame = ({
 }: PropsWithChildren<FrameWrapperProps>) => {
   const { t: ct } = useTranslation('translation', { keyPrefix: 'common' });
   const { t } = useTranslation('translation', { keyPrefix: 'page' });
-  const [pageLocation] = useSocketMessageStore((state) => [
+  const [pageLocation, clientInfo] = useSocketMessageStore((state) => [
     state.pageMsg.location,
+    state.clientInfo,
   ]);
   const [elementVisible, setElementVisible] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -98,7 +98,6 @@ export const PCFrame = ({
 
   const [enableDevice, setEnableDevice] = useState(false);
 
-  const clientInfo = useClientInfoFromMsg();
   useEffect(() => {
     if (!clientInfo) return;
     if (['ios', 'ipad', 'android'].indexOf(clientInfo.os.type) >= 0) {

--- a/src/pages/Devtools/ConsolePanel/components/FooterInput/index.tsx
+++ b/src/pages/Devtools/ConsolePanel/components/FooterInput/index.tsx
@@ -12,7 +12,6 @@ import { useRef, useState, useEffect, useCallback, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { KeyboardEvent } from 'react';
 import { useMiscStore } from '@/store/misc';
-import { useClientInfoFromMsg } from '@/utils/brand';
 import { parse, Program } from 'acorn';
 
 const EXECUTE_HISTORY_ID = 'page_spy_execute_history';
@@ -20,11 +19,11 @@ const EXECUTE_HISTORY_MAX_SIZE = 100;
 
 export const FooterInput = memo(() => {
   const { t } = useTranslation('translation', { keyPrefix: 'console' });
-  const [socket, clearRecord] = useSocketMessageStore((state) => [
+  const [socket, clearRecord, clientInfo] = useSocketMessageStore((state) => [
     state.socket,
     state.clearRecord,
+    state.clientInfo,
   ]);
-  const clientInfo = useClientInfoFromMsg();
 
   const inputRef = useRef<TextAreaRef | null>(null);
   const [code, setCode] = useState<string>('');

--- a/src/pages/Devtools/ConsolePanel/index.tsx
+++ b/src/pages/Devtools/ConsolePanel/index.tsx
@@ -4,11 +4,11 @@ import { HeaderActions } from './components/HeaderActions';
 import { MainContent } from './components/MainContent';
 import { FooterInput } from './components/FooterInput';
 import { ErrorDetailDrawer } from './components/ErrorDetailDrawer';
-import { useClientInfoFromMsg } from '@/utils/brand';
 import { useMemo } from 'react';
+import { useSocketMessageStore } from '@/store/socket-message';
 
 const ConsolePanel = () => {
-  const clientInfo = useClientInfoFromMsg();
+  const clientInfo = useSocketMessageStore((state) => state.clientInfo);
   const dynamicalExecutable = useMemo(() => {
     const { os } = clientInfo || {};
     // TODO 纯血鸿蒙出来后需要额外判断是「鸿蒙上的 APP」

--- a/src/pages/Devtools/index.tsx
+++ b/src/pages/Devtools/index.tsx
@@ -23,14 +23,14 @@ import './index.less';
 import { StoragePanel } from './StoragePanel';
 import useSearch from '@/utils/useSearch';
 import { useEventListener } from '@/utils/useEventListener';
-import { parseUserAgent, useClientInfoFromMsg } from '@/utils/brand';
+import { parseUserAgent } from '@/utils/brand';
 import { useTranslation } from 'react-i18next';
 import { ConnectStatus } from './ConnectStatus';
 import { useSocketMessageStore } from '@/store/socket-message';
 import '@huolala-tech/react-json-view/dist/style.css';
 import { throttle } from 'lodash-es';
 import { CUSTOM_EVENT } from '@/store/socket-message/socket';
-import { SpyDevice } from '@huolala-tech/page-spy-types';
+import { SpyClient } from '@huolala-tech/page-spy-types';
 import MPWarning from '@/components/MPWarning';
 
 const { Sider, Content } = Layout;
@@ -43,8 +43,8 @@ const MENU_COMPONENTS: Record<
   {
     component: React.FC;
     visible?: (params: {
-      browser: SpyDevice.Browser;
-      os: SpyDevice.OS;
+      browser: SpyClient.Browser;
+      os: SpyClient.OS;
     }) => boolean;
   }
 > = {
@@ -119,7 +119,7 @@ const BadgeMenu = memo(({ active }: BadgeMenuProps) => {
     }));
   }, [active]);
 
-  const clientInfo = useClientInfoFromMsg();
+  const clientInfo = useSocketMessageStore((socket) => socket.clientInfo);
 
   const menuItems = useMemo(() => {
     if (!clientInfo) return [];
@@ -253,7 +253,7 @@ const SiderRooms: React.FC<SiderRoomProps> = ({ exclude }) => {
 const ClientInfo = memo(() => {
   const { t } = useTranslation('translation', { keyPrefix: 'devtool' });
   const { address = '' } = useSearch();
-  const clientInfo = useClientInfoFromMsg();
+  const clientInfo = useSocketMessageStore((state) => state.clientInfo);
 
   return (
     <div className="client-info">
@@ -312,12 +312,11 @@ const ClientInfo = memo(() => {
 export default function Devtools() {
   const { hash = '#Console' } = useLocation();
   const { address = '', secret = '' } = useSearch();
-  const [socket, initSocket] = useSocketMessageStore((state) => [
+  const [socket, initSocket, clientInfo] = useSocketMessageStore((state) => [
     state.socket,
     state.initSocket,
+    state.clientInfo,
   ]);
-
-  const clientInfo = useClientInfoFromMsg();
 
   useEffect(() => {
     if (socket) return;

--- a/src/store/platform-config.ts
+++ b/src/store/platform-config.ts
@@ -1,15 +1,15 @@
-import { useClientInfoFromMsg } from '@/utils/brand';
 import { ReactComponent as StorageSvg } from '@/assets/image/storage.svg';
 import { ReactComponent as CookieSvg } from '@/assets/image/cookie.svg';
 import { ReactComponent as DatabaseSvg } from '@/assets/image/database.svg';
-import { SpyDevice, SpyStorage } from '@huolala-tech/page-spy-types';
+import { SpyClient, SpyStorage } from '@huolala-tech/page-spy-types';
 import { FunctionComponent } from 'react';
+import { useSocketMessageStore } from './socket-message';
 
 export const STORAGE_TYPES: {
   name: SpyStorage.DataType | 'indexedDB';
   label: string;
   icon: FunctionComponent;
-  visible: (browser?: SpyDevice.Browser) => boolean;
+  visible: (browser?: SpyClient.Browser) => boolean;
 }[] = [
   {
     name: 'localStorage',
@@ -49,7 +49,7 @@ export const STORAGE_TYPES: {
 ];
 
 export const useStorageTypes = () => {
-  const clientInfo = useClientInfoFromMsg();
+  const clientInfo = useSocketMessageStore((state) => state.clientInfo);
   return STORAGE_TYPES.filter((s) => {
     return s.visible(clientInfo?.browser.type);
   });

--- a/src/store/socket-message/message-type.ts
+++ b/src/store/socket-message/message-type.ts
@@ -1,4 +1,5 @@
 export const CONNECT = 'connect';
+export const CLIENT_INFO = 'client-info';
 export const CONSOLE = 'console';
 export const SYSTEM = 'system';
 export const NETWORK = 'network';


### PR DESCRIPTION
之前调试端依赖 system 信息决定界面渲染，而system 信息发送可能滞后导致页面响应时间过长。
现将调试端所需信息统一放在 client-info 消息里，在调试端连上后立马发送。