### PR TITLE
feat: limit showed connections in /room-list

### DIFF
--- a/src/assets/locales/en.json
+++ b/src/assets/locales/en.json
@@ -182,7 +182,13 @@
   "connections": {
     "select-os": "Select OS",
     "select-browser": "Select browser",
-    "select-mp": "Select Mini Program"
+    "select-mp": "Select Mini Program",
+    "maximum-alert": "Just show partial connections. Please further filter through the conditions.",
+    "status": {
+      "active": "Debugging",
+      "wait": "Pending Debug",
+      "inactive": "Unable to Debug"
+    }
   },
   "replay": {
     "list-title": "Replay List",

--- a/src/assets/locales/ja.json
+++ b/src/assets/locales/ja.json
@@ -182,7 +182,13 @@
   "connections": {
     "select-os": "オペレーティング システムを選択",
     "select-browser": "ブラウザを選択",
-    "select-mp": "Mini Program を選択"
+    "select-mp": "Mini Program を選択",
+    "maximum-alert": "一部の接続のみが表示されます。条件によってさらに絞り込んでください。",
+    "status": {
+      "active": "デバッグ中",
+      "wait": "デバッグ待ち",
+      "inactive": "デバッグ不可"
+    }
   },
   "replay": {
     "list-title": "再生リスト",

--- a/src/assets/locales/ko.json
+++ b/src/assets/locales/ko.json
@@ -182,7 +182,13 @@
   "connections": {
     "select-os": "운영 체제 선택",
     "select-browser": "브라우저 선택",
-    "select-mp": "Mini Program 선택"
+    "select-mp": "Mini Program 선택",
+    "maximum-alert": "일부 연결만 표시됩니다. 조건을 통해 추가로 필터링하세요.",
+    "status": {
+      "active": "디버깅 중",
+      "wait": "디버깅 대기 중",
+      "inactive": "디버깅 불가"
+    }
   },
   "replay": {
     "list-title": "재생 목록",

--- a/src/assets/locales/zh.json
+++ b/src/assets/locales/zh.json
@@ -182,7 +182,13 @@
   "connections": {
     "select-os": "选择系统",
     "select-browser": "选择浏览器",
-    "select-mp": "选择小程序"
+    "select-mp": "选择小程序",
+    "maximum-alert": "当前待调试终端较多，请通过条件进一步筛选",
+    "status": {
+      "active": "调试中",
+      "wait": "待调试",
+      "inactive": "无法调试"
+    }
   },
   "replay": {
     "list-title": "回放列表",

--- a/src/pages/RoomList/Statistics/index.tsx
+++ b/src/pages/RoomList/Statistics/index.tsx
@@ -1,0 +1,63 @@
+import { ClientRoomInfo } from '@/utils/brand';
+import { Row, Col } from 'antd';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  data: ClientRoomInfo[];
+}
+
+export const Statistics = memo(({ data }: Props) => {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'connections.status',
+  });
+
+  const { active, wait, inactive } = data.reduce(
+    (acc, cur) => {
+      const { connections } = cur;
+      let hasClient: boolean = false;
+      let hasDebugger: boolean = false;
+
+      for (let k = 0; k <= connections.length - 1; k++) {
+        const { userId } = connections[k];
+        if (userId === 'Client') {
+          hasClient = true;
+        }
+        if (userId === 'Debugger') {
+          hasDebugger = true;
+        }
+        if (hasClient && hasDebugger) break;
+      }
+      if (hasClient && hasDebugger) {
+        acc.active.push(cur);
+      } else if (hasClient) {
+        acc.wait.push(cur);
+      } else {
+        acc.inactive.push(cur);
+      }
+      return acc;
+    },
+    {
+      active: [],
+      wait: [],
+      inactive: [],
+    } as Record<'active' | 'wait' | 'inactive', ClientRoomInfo[]>,
+  );
+
+  return (
+    <Row justify="space-between" className="statistic">
+      <Col className="statistics-item">
+        <p>{t('active')}</p>
+        <p style={{ color: '#389e0d' }}>{active.length}</p>
+      </Col>
+      <Col className="statistics-item">
+        <p>{t('wait')}</p>
+        <p style={{ color: '#faad14' }}>{wait.length}</p>
+      </Col>
+      <Col className="statistics-item">
+        <p>{t('inactive')}</p>
+        <p style={{ color: '#bfbfbf' }}>{inactive.length}</p>
+      </Col>
+    </Row>
+  );
+});

--- a/src/pages/RoomList/index.less
+++ b/src/pages/RoomList/index.less
@@ -1,4 +1,39 @@
 .room-list {
+  &-sider {
+    height: 100%;
+    display: grid;
+    padding: 24px;
+    grid-template-rows: auto 1fr auto;
+    .maximum-alert {
+      position: relative;
+      font-size: 12px;
+      text-align: right;
+      color: fade(@primary-color, 90%);
+      &::before {
+        content: '*';
+        color: red;
+        font-size: 14px;
+        font-weight: 500;
+        margin-right: 2px;
+      }
+    }
+    .statistics {
+      &-item {
+        text-align: center;
+        p:nth-child(1) {
+          font-size: 12px;
+          color: #999;
+          text-align: center;
+          margin-bottom: 8px;
+        }
+        p:nth-child(2) {
+          cursor: pointer;
+          font-size: 20px;
+          font-weight: 500;
+        }
+      }
+    }
+  }
   .connection-item {
     margin-bottom: 24px;
     padding: 12px;

--- a/src/pages/RoomList/index.tsx
+++ b/src/pages/RoomList/index.tsx
@@ -2,6 +2,7 @@ import { getSpyRoom } from '@/apis';
 import {
   AllBrowserTypes,
   AllMPTypes,
+  ClientRoomInfo,
   OS_CONFIG,
   getBrowserLogo,
   getBrowserName,
@@ -26,12 +27,15 @@ import { useTranslation } from 'react-i18next';
 import './index.less';
 import { ClearOutlined, SearchOutlined } from '@ant-design/icons';
 import { RoomCard } from './RoomCard';
+import { Statistics } from './Statistics';
 
 const { Title } = Typography;
 const { Option } = Select;
 const { Sider, Content } = Layout;
 
-const sortConnections = (data: I.SpyRoom[]) => {
+const MAXIMUM_CONNECTIONS = 30;
+
+const sortConnections = (data: ClientRoomInfo[]) => {
   const [valid, invalid] = (data || []).reduce(
     (acc, cur) => {
       const hasClient =
@@ -62,7 +66,7 @@ const sortConnections = (data: I.SpyRoom[]) => {
 };
 
 const filterConnections = (
-  data: I.SpyRoom[],
+  data: ClientRoomInfo[],
   condition: Record<'title' | 'address' | 'os' | 'browser', string>,
 ) => {
   const { title = '', address = '', os = '', browser = '' } = condition;
@@ -72,8 +76,7 @@ const filterConnections = (
       return String(tags.title).toLowerCase().includes(lowerCaseTitle);
     })
     .filter((i) => i.address.slice(0, 4).includes(address || ''))
-    .filter(({ name }) => {
-      const clientInfo = parseUserAgent(name);
+    .filter((clientInfo) => {
       return (
         (!os || clientInfo.os.type === os) &&
         (!browser || clientInfo.browser.type.includes(browser))
@@ -85,6 +88,9 @@ export const RoomList = () => {
   const [form] = Form.useForm();
   const { t } = useTranslation();
 
+  const showDashboard = localStorage.getItem('page-spy-dashboard') === '1';
+
+  const [showMaximumAlert, setMaximumAlert] = useState(false);
   const {
     data: connectionList = [],
     error,
@@ -170,10 +176,15 @@ export const RoomList = () => {
         />
       );
 
-    const list = sortConnections(filterConnections(connectionList, conditions));
+    const matchedConnections = filterConnections(connectionList, conditions);
+    setMaximumAlert(matchedConnections.length > MAXIMUM_CONNECTIONS);
+
+    const list = sortConnections(
+      matchedConnections.slice(0, MAXIMUM_CONNECTIONS),
+    );
 
     return (
-      <Row gutter={24}>
+      <Row gutter={24} style={{ padding: 24 }}>
         {list.map((room) => (
           <RoomCard key={room.address} room={room} />
         ))}
@@ -183,102 +194,111 @@ export const RoomList = () => {
 
   return (
     <Layout style={{ height: '100%' }} className="room-list">
-      <Sider width={350} theme="light" style={{ padding: 24 }}>
-        <Title level={3} style={{ marginBottom: 32 }}>
-          {t('common.connections')}
-        </Title>
-        <Form layout="vertical" form={form} onFinish={onFormFinish}>
-          <Form.Item label={t('common.device-id')} name="address">
-            <Input placeholder={t('common.device-id')!} allowClear />
-          </Form.Item>
-          <Form.Item label={t('common.project')} name="project">
-            <Input placeholder={t('common.project')!} allowClear />
-          </Form.Item>
-          <Form.Item label={t('common.title')} name="title">
-            <Input placeholder={t('common.title')!} allowClear />
-          </Form.Item>
-          <Form.Item label={t('common.os')} name="os">
-            <Select placeholder={t('connections.select-os')} allowClear>
-              {Object.entries(OS_CONFIG).map(([name, conf]) => {
-                return (
-                  <Option value={name} key={name}>
-                    <div className="flex-between">
-                      <span>{conf.label}</span>
-                      <img src={conf.logo} height="20" alt="" />
-                    </div>
-                  </Option>
-                );
-              })}
-            </Select>
-          </Form.Item>
-          <Form.Item label={t('common.browser')} name="browser">
-            <Select
-              listHeight={500}
-              placeholder={t('connections.select-browser')}
-              allowClear
-            >
-              {!!BrowserOptions.length && (
-                <Select.OptGroup label="Web" key="web">
-                  {BrowserOptions.map(({ name, logo, label }) => {
-                    return (
-                      <Option key={name} value={name}>
-                        <div className="flex-between">
-                          <span>{label}</span>
-                          <img src={logo} width="20" height="20" alt="" />
-                        </div>
-                      </Option>
-                    );
-                  })}
-                </Select.OptGroup>
-              )}
+      <Sider width={350} theme="light">
+        <div className="room-list-sider">
+          <Title level={3} style={{ marginBottom: 32 }}>
+            {t('common.connections')}
+          </Title>
+          <Form layout="vertical" form={form} onFinish={onFormFinish}>
+            <Form.Item label={t('common.device-id')} name="address">
+              <Input placeholder={t('common.device-id')!} allowClear />
+            </Form.Item>
+            <Form.Item label={t('common.project')} name="project">
+              <Input placeholder={t('common.project')!} allowClear />
+            </Form.Item>
+            <Form.Item label={t('common.title')} name="title">
+              <Input placeholder={t('common.title')!} allowClear />
+            </Form.Item>
+            <Form.Item label={t('common.os')} name="os">
+              <Select placeholder={t('connections.select-os')} allowClear>
+                {Object.entries(OS_CONFIG).map(([name, conf]) => {
+                  return (
+                    <Option value={name} key={name}>
+                      <div className="flex-between">
+                        <span>{conf.label}</span>
+                        <img src={conf.logo} height="20" alt="" />
+                      </div>
+                    </Option>
+                  );
+                })}
+              </Select>
+            </Form.Item>
+            <Form.Item label={t('common.browser')} name="browser">
+              <Select
+                listHeight={500}
+                placeholder={t('connections.select-browser')}
+                allowClear
+              >
+                {!!BrowserOptions.length && (
+                  <Select.OptGroup label="Web" key="web">
+                    {BrowserOptions.map(({ name, logo, label }) => {
+                      return (
+                        <Option key={name} value={name}>
+                          <div className="flex-between">
+                            <span>{label}</span>
+                            <img src={logo} width="20" height="20" alt="" />
+                          </div>
+                        </Option>
+                      );
+                    })}
+                  </Select.OptGroup>
+                )}
 
-              {!!MPTypeOptions.length && (
-                <Select.OptGroup
-                  label={t('common.miniprogram')}
-                  key="miniprogram"
-                >
-                  {MPTypeOptions.map(({ name, logo, label }) => {
-                    return (
-                      <Option key={name} value={name}>
-                        <div className="flex-between">
-                          <span>{label}</span>
-                          <img src={logo} width="20" height="20" alt="" />
-                        </div>
-                      </Option>
-                    );
-                  })}
-                </Select.OptGroup>
-              )}
-            </Select>
-          </Form.Item>
-          <Row justify="end">
-            <Col>
-              <Form.Item>
-                <Space>
-                  <Button
-                    type="primary"
-                    htmlType="submit"
-                    icon={<SearchOutlined />}
+                {!!MPTypeOptions.length && (
+                  <Select.OptGroup
+                    label={t('common.miniprogram')}
+                    key="miniprogram"
                   >
-                    {t('common.search')}
-                  </Button>
-                  <Button
-                    type="default"
-                    icon={<ClearOutlined />}
-                    onClick={() => {
-                      form.resetFields();
-                      form.submit();
-                    }}
-                  >
-                    {t('common.reset')}
-                  </Button>
-                </Space>
-              </Form.Item>
-            </Col>
-          </Row>
-        </Form>
+                    {MPTypeOptions.map(({ name, logo, label }) => {
+                      return (
+                        <Option key={name} value={name}>
+                          <div className="flex-between">
+                            <span>{label}</span>
+                            <img src={logo} width="20" height="20" alt="" />
+                          </div>
+                        </Option>
+                      );
+                    })}
+                  </Select.OptGroup>
+                )}
+              </Select>
+            </Form.Item>
+            <Row justify="end">
+              <Col>
+                <Form.Item>
+                  <Space>
+                    <Button
+                      type="primary"
+                      htmlType="submit"
+                      icon={<SearchOutlined />}
+                    >
+                      {t('common.search')}
+                    </Button>
+                    <Button
+                      type="default"
+                      icon={<ClearOutlined />}
+                      onClick={() => {
+                        form.resetFields();
+                        form.submit();
+                      }}
+                    >
+                      {t('common.reset')}
+                    </Button>
+                  </Space>
+                </Form.Item>
+              </Col>
+            </Row>
+
+            {showMaximumAlert && (
+              <div className="maximum-alert">
+                {t('connections.maximum-alert')}
+              </div>
+            )}
+          </Form>
+          {showDashboard && <Statistics data={connectionList} />}
+        </div>
       </Sider>
-      <Content style={{ padding: 24 }}>{mainContent}</Content>
+      <Content>{mainContent}</Content>
     </Layout>
   );
 };

--- a/src/utils/brand.ts
+++ b/src/utils/brand.ts
@@ -51,6 +51,8 @@ interface ClientInfo {
   framework?: Framework;
 }
 
+export type ClientRoomInfo = I.SpyRoom & ClientInfo;
+
 // Make miniprogram browser types
 export const AllMPTypes: SpyDevice.MPType[] = [
   'mp-wechat',


### PR DESCRIPTION
- `/room-list` 限制展示连接数量，避免连接数过多影响页面渲染性能；
- 通过在 localStorage 中设置 `page-spy-dashboard: 1` ，在侧边栏左下角显示连接汇总信息；

close #203 