### PR TITLE
fix: Handle query params in getFileExtension function

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,9 +5,14 @@ export function getObjectKeys<T extends Record<string, any>>(data: T) {
 export function getFileExtension(url: string) {
   const origin = url.trim();
   if (!origin) return '';
-  const lastDotIndex = origin.lastIndexOf('.');
+  
+  // 移除查询参数
+  const pathWithoutQuery = origin.split('?')[0];
+  
+  const lastDotIndex = pathWithoutQuery.lastIndexOf('.');
   if (lastDotIndex === -1) return '';
-  return origin.substring(lastDotIndex + 1);
+  
+  return pathWithoutQuery.substring(lastDotIndex + 1);
 }
 
 export function resolveProtocol() {


### PR DESCRIPTION
 https://github.com/HuolalaTech/page-spy-web/issues/215
修复这个source map 里文件后缀获取逻辑的问题